### PR TITLE
Fixed merge conflict issues

### DIFF
--- a/SchedulerGUI/ViewModels/MainWindowViewModel.cs
+++ b/SchedulerGUI/ViewModels/MainWindowViewModel.cs
@@ -254,7 +254,8 @@ namespace SchedulerGUI.ViewModels
                 //    });
                 //}
             }
-            
+        }
+
         private void OpenAboutHandler()
         {
             this.DialogManager.PopupDialog = new AboutDialogViewModel();

--- a/WPF/TimelineLib/TimelineLib.csproj
+++ b/WPF/TimelineLib/TimelineLib.csproj
@@ -60,10 +60,6 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ColorWheel.Core, Version=1.5.10.51312, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\ColorWheel.Core.1.5.10.51312\lib\net40\ColorWheel.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -160,7 +156,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -228,7 +223,11 @@
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="ColorWheel.Core">
+      <Version>1.5.10.51312</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/WPF/TimelineLib/packages.config
+++ b/WPF/TimelineLib/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="ColorWheel.Core" version="1.5.10.51312" />
-</packages>


### PR DESCRIPTION
Resolves issues from PR #8 (repeated as #11 )

- Missing brace
- Converted TimelineLib to PackageRef and fixed invalid NuGet cache path for ColorWheel.Core