### PR TITLE
Fix timeline lib building

### DIFF
--- a/externals/TimelineLib/Silverlight/TimelineLib/Controls/TimelineTray.cs
+++ b/externals/TimelineLib/Silverlight/TimelineLib/Controls/TimelineTray.cs
@@ -68,7 +68,6 @@ namespace TimelineLibrary
 
         private List<TimelineBand>                      m_bands;
         private TimelineEventStore                      m_eventStore;
-        private TimelineEventStore                      m_eventStorePhases;
         private bool                                    m_changingDate;
         private DataControlNotifier                     m_notifier;   
         private string                                  m_cultureId = DateTimeConverter.DEFAULT_CULTUREID;    
@@ -133,21 +132,19 @@ namespace TimelineLibrary
 
         public static void OnCurrentDateTimeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            TimelineTray t= d as TimelineTray;
-
-            if (t != null && e.NewValue != e.OldValue)
+            if (d is TimelineTray t && e.NewValue != e.OldValue)
             {
-                if ((DateTime) e.NewValue < t.MinDateTime)
+                if ((DateTime)e.NewValue < t.MinDateTime)
                 {
                     t.SetValue(CurrentDateTimeProperty, t.MinDateTime);
                 }
-                else if ((DateTime) e.NewValue > t.MaxDateTime)
+                else if ((DateTime)e.NewValue > t.MaxDateTime)
                 {
                     t.SetValue(CurrentDateTimeProperty, t.MaxDateTime);
                 }
-                else 
+                else
                 {
-                    t.m_currentDateTime = (DateTime) e.NewValue;
+                    t.m_currentDateTime = (DateTime)e.NewValue;
                     if (t.MainBand != null)
                     {
                         t.MainBand.CurrentDateTime = t.m_currentDateTime;
@@ -194,15 +191,13 @@ namespace TimelineLibrary
 
         public static void OnMinDateTimeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            TimelineTray t= d as TimelineTray;
-
-            if (t != null && e.NewValue != e.OldValue)
+            if (d is TimelineTray t && e.NewValue != e.OldValue)
             {
-                if ((DateTime) e.NewValue >= t.MaxDateTime)
+                if ((DateTime)e.NewValue >= t.MaxDateTime)
                 {
                     throw new ArgumentOutOfRangeException("MinDateTime cannot be more then MaxDateTime");
                 }
-                else if (t.CurrentDateTime < (DateTime) e.NewValue)
+                else if (t.CurrentDateTime < (DateTime)e.NewValue)
                 {
                     t.SetValue(CurrentDateTimeProperty, e.NewValue);
                 }
@@ -211,7 +206,7 @@ namespace TimelineLibrary
                 {
                     if (b.Calculator != null && b.Calculator.Calendar != null)
                     {
-                        b.Calculator.Calendar.MinDateTime = ((DateTime) e.NewValue);
+                        b.Calculator.Calendar.MinDateTime = ((DateTime)e.NewValue);
                     }
                 }
             }
@@ -236,15 +231,13 @@ namespace TimelineLibrary
 
         public static void OnMaxDateTimeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            TimelineTray t = d as TimelineTray;
-
-            if (t != null && e.NewValue != e.OldValue)
+            if (d is TimelineTray t && e.NewValue != e.OldValue)
             {
-                if ((DateTime) e.NewValue < t.MinDateTime)
+                if ((DateTime)e.NewValue < t.MinDateTime)
                 {
                     throw new ArgumentOutOfRangeException("MaxDateTime cannot be less then MinDateTime");
                 }
-                else if (t.CurrentDateTime >= (DateTime) e.NewValue)
+                else if (t.CurrentDateTime >= (DateTime)e.NewValue)
                 {
                     t.SetValue(CurrentDateTimeProperty, e.NewValue);
                 }
@@ -253,7 +246,7 @@ namespace TimelineLibrary
                 {
                     if (b.Calculator != null && b.Calculator.Calendar != null)
                     {
-                        b.Calculator.Calendar.MaxDateTime = ((DateTime) e.NewValue);
+                        b.Calculator.Calendar.MaxDateTime = ((DateTime)e.NewValue);
                     }
                 }
             }
@@ -396,7 +389,9 @@ namespace TimelineLibrary
                     b.ClearEvents();
 
                     if (b.IsMainBand)
+                    {
                         b.EventStore = m_eventStore;
+                    }
                 }
 
                 MainBand.CalculateEventRows();
@@ -795,7 +790,7 @@ namespace TimelineLibrary
             TimelineReady?.Invoke(this, new EventArgs());
         }
 
-        protected virtual void Initialized()
+        protected new virtual void Initialized()
         {}
 
         /// <summary>

--- a/externals/TimelineLib/WPF/TimelineLib/TimelineLibrary.csproj
+++ b/externals/TimelineLib/WPF/TimelineLib/TimelineLibrary.csproj
@@ -49,6 +49,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>IDE0009</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -58,6 +59,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>IDE0009</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/externals/TimelineLib/WPF/TimelineLib/TimelineLibrary.csproj
+++ b/externals/TimelineLib/WPF/TimelineLib/TimelineLibrary.csproj
@@ -87,9 +87,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AsmInfo.cs">
-      <Link>Properties\AsmInfo.cs</Link>
-    </Compile>
     <Compile Include="..\..\Silverlight\TimelineLib\Compatibility.cs">
       <Link>Compatibility.cs</Link>
     </Compile>


### PR DESCRIPTION
- Fixes the build issue on some computers with TimelineLib failing due to duplicate inclusion of AsmInfo.cs
- Fixes or suppresses a bunch of warnings and messages in VS about code formatting and quality for TimelineLib