### PR TITLE
Std. Dev. for joules on the profile graph shows a metric formatted unit

### DIFF
--- a/SchedulerGUI/Converters/MetricToStringConverter.cs
+++ b/SchedulerGUI/Converters/MetricToStringConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using SchedulerDatabase.Helpers;
+
+namespace SchedulerGUI.Converters
+{
+    /// <summary>
+    /// <see cref="MetricToStringConverter"/> provides a converter to display metric values as a user-friendly string.
+    /// </summary>
+    public sealed class MetricToStringConverter : IValueConverter
+    {
+        /// <inheritdoc />
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is double v)
+            {
+                return MetricUtils.MetricValueAxisLabelFormatter(v, parameter?.ToString(), false);
+            }
+
+            return string.Empty;
+        }
+
+        /// <inheritdoc />
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SchedulerGUI/SchedulerGUI.csproj
+++ b/SchedulerGUI/SchedulerGUI.csproj
@@ -69,6 +69,7 @@
     </ApplicationDefinition>
     <Compile Include="Converters\EnumBindingSourceExtension.cs" />
     <Compile Include="Converters\AcceleratorToStringConverter.cs" />
+    <Compile Include="Converters\MetricToStringConverter.cs" />
     <Compile Include="Converters\HzToStringConverter.cs" />
     <Compile Include="Converters\ImageUtils.cs" />
     <Compile Include="Converters\NullToVisibilityConverter.cs" />

--- a/SchedulerGUI/Styles/GlobalResources.xaml
+++ b/SchedulerGUI/Styles/GlobalResources.xaml
@@ -6,5 +6,6 @@
     <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter" />
     
     <converters:NullToVisibilityConverter x:Key="nullToVisibilityConverter"/>
+    <converters:MetricToStringConverter x:Key="metricToStringConverter" />
 
 </ResourceDictionary>

--- a/SchedulerGUI/Views/Controls/ProfileGraphControl.xaml
+++ b/SchedulerGUI/Views/Controls/ProfileGraphControl.xaml
@@ -24,7 +24,7 @@
 
         <TextBlock Grid.Row="1"
                    Grid.Column="0"
-                   Text="{Binding JoulesPerByteStdDev, StringFormat=Joules Per Byte Std. Dev. {0:0.00000}}"
+                   Text="{Binding JoulesPerByteStdDev, StringFormat=Joules Per Byte Std. Dev. {0},  Converter={StaticResource metricToStringConverter}, ConverterParameter=J}"
                    HorizontalAlignment="Center" />
 
         <TextBlock Grid.Row="1"


### PR DESCRIPTION
The standard deviation for joules/byte on the profile graph shows the value with a metric formatted suffix. Previously, the values were so small they did not show up in 4 decimal places. Now, small values with show as 1.234nJ, 1.234uJ, etc., based on the appropriate suffix.